### PR TITLE
Add support for .mjs files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gunzip-maybe": "^1.4.0",
     "invariant": "^2.2.2",
     "isomorphic-fetch": "^2.2.1",
-    "mime": "^1.3.6",
+    "mime": "^1.4.0",
     "mkdirp": "^0.5.1",
     "morgan": "^1.8.1",
     "ndjson": "^1.5.0",


### PR DESCRIPTION
Right now these are served as `application/octect-stream`.

The latest mime module with [latest mime-db](https://github.com/jshttp/mime-db/blob/master/db.json#L503-L508) thought would serve them as `application/javascript`.

This would enable direct `index.mjs` access without needing `?module` or runtime transpilation.

Examples:
`unpkg.com/hyperhtml@latest/index.mjs`
`unpkg.com/hyperhtml@latest/min.mjs`

Please note GitHub is already serving the correct mime-type when it comes to `.mjs` files and, as ugly as a solution, I think `unpkg` should simply follow.

Thanks for updating this service.